### PR TITLE
Only set authorized_keys if variable is set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,9 @@
 
 dpkg-reconfigure openssh-server
 
-echo $BORG_AUTHORIZED_KEYS > /home/borg/.ssh/authorized_keys
-chown borg.borg /home/borg/.ssh/authorized_keys
+if [ -z ${BORG_AUTHORIZED_KEYS+x} ]; then
+  echo $BORG_AUTHORIZED_KEYS > /home/borg/.ssh/authorized_keys
+  chown borg.borg /home/borg/.ssh/authorized_keys
+fi
 
 exec /usr/sbin/sshd -D


### PR DESCRIPTION
Avoid overwriting file, if BORG_AUTHORIZED_KEYS is not present.

By doing this, allows mounting authorized_keys into the container - making support for multiple keys or special configuration.